### PR TITLE
기능추가: JPA 엔티티 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+src/**/secret.yml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,16 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	implementation 'io.jsonwebtoken:jjwt:0.9.1'
+
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
+
+	testCompile('com.h2database:h2')
+
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
 	}

--- a/src/main/java/com/devpedia/watchapedia/WatchapediaApplication.java
+++ b/src/main/java/com/devpedia/watchapedia/WatchapediaApplication.java
@@ -2,12 +2,17 @@ package com.devpedia.watchapedia;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.builder.SpringApplicationBuilder;
 
 @SpringBootApplication
 public class WatchapediaApplication {
+	private static final String PROPERTIES = "spring.config.location=" +
+			"classpath:/application.yml" +
+			",classpath:/secret.yml";
 
 	public static void main(String[] args) {
-		SpringApplication.run(WatchapediaApplication.class, args);
+		new SpringApplicationBuilder(WatchapediaApplication.class)
+				.properties(PROPERTIES)
+				.run(args);
 	}
-
 }

--- a/src/main/java/com/devpedia/watchapedia/config/JpaAuditConfig.java
+++ b/src/main/java/com/devpedia/watchapedia/config/JpaAuditConfig.java
@@ -1,0 +1,9 @@
+package com.devpedia.watchapedia.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditConfig {
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/BaseEntity.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(value = {AuditingEntityListener.class})
+@Getter
+public abstract class BaseEntity {
+    @CreatedDate
+    private LocalDateTime createDatetime;
+
+    @LastModifiedDate
+    private LocalDateTime updateDatetime;
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/Book.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Book.java
@@ -1,0 +1,38 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import java.time.LocalDate;
+
+@Entity
+@DiscriminatorValue("B")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Book extends Content {
+
+    @Column(nullable = false)
+    private String subtitle;
+
+    @Column(nullable = false)
+    private Integer page;
+
+    private String contents;
+
+    private String elaboration;
+
+    @Builder
+    public Book(Image posterImage, String mainTitle, String category, LocalDate productionDate, String descrption,
+                String subtitle, Integer page, String contents, String elaboration) {
+        super(posterImage, mainTitle, category, productionDate, descrption);
+        this.subtitle = subtitle;
+        this.page = page;
+        this.contents = contents;
+        this.elaboration = elaboration;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/Collection.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Collection.java
@@ -1,0 +1,50 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "delete_yn = 'N'")
+public class Collection extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "collection_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(name = "delete_yn", nullable = false)
+    private Boolean isDeleted;
+
+    @Builder
+    public Collection(User user, String title, String description) {
+        this.user = user;
+        this.title = title;
+        this.description = description;
+        this.isDeleted = false;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/CollectionContent.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/CollectionContent.java
@@ -1,0 +1,45 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CollectionContent {
+
+    @EmbeddedId
+    private CollectionContentId id;
+
+    @MapsId("contentId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cotent_id")
+    private Content content;
+
+    @MapsId("collectionId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "collection_id")
+    private Collection collection;
+
+    @Builder
+    public CollectionContent(Content content, Collection collection) {
+        this.id = new CollectionContentId(content.getId(), collection.getId());
+        this.content = content;
+        this.collection = collection;
+    }
+
+    public void setContent(Content content) {
+        this.content = content;
+    }
+
+    @Embeddable
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CollectionContentId implements Serializable {
+        private Long contentId;
+        private Long collectionId;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/Comment.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Comment.java
@@ -1,0 +1,64 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.*;
+import org.hibernate.annotations.Where;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "delete_yn = 'N'")
+public class Comment extends BaseEntity {
+
+    @EmbeddedId
+    private CommentId id;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @MapsId("contentId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private Content content;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(name = "spoiler_yn", nullable = false)
+    private Boolean containsSpoiler;
+
+    @Column(name = "delete_yn", nullable = false)
+    private Boolean isDeleted;
+
+    @Builder
+    public Comment(User user, Content content, String description, Boolean containsSpoiler) {
+        this.id = new CommentId(user.getId(), content.getId());
+        this.user = user;
+        this.content = content;
+        this.description = description;
+        this.containsSpoiler = containsSpoiler;
+        this.isDeleted = false;
+    }
+
+    public void setContent(Content content) {
+        this.content = content;
+    }
+
+    @Embeddable
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CommentId implements Serializable {
+        private Long userId;
+        private Long contentId;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/CommentLike.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/CommentLike.java
@@ -1,0 +1,44 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommentLike {
+
+    @EmbeddedId
+    private CommentLikeId id;
+
+    @MapsId("likeUserId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "like_user_id", referencedColumnName = "user_id")
+    private User user;
+
+    @MapsId("commentId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumns({
+            @JoinColumn(name = "comment_user_id", referencedColumnName = "user_id"),
+            @JoinColumn(name = "content_id", referencedColumnName = "content_id")
+    })
+    private Comment comment;
+
+    @Builder
+    public CommentLike(User user, Comment comment) {
+        this.id = new CommentLikeId(comment.getId(), user.getId());
+        this.user = user;
+        this.comment = comment;
+    }
+
+    @Embeddable
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CommentLikeId implements Serializable {
+        private Comment.CommentId commentId;
+        private Long likeUserId;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/Content.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Content.java
@@ -1,0 +1,71 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@Getter
+@DiscriminatorColumn(name = "dtype")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class Content {
+
+    @Id @GeneratedValue
+    @Column(name = "content_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "image_id")
+    private Image posterImage;
+
+    @Column(nullable = false)
+    private String mainTitle;
+
+    @Column(nullable = false)
+    private String category;
+
+    @Column(nullable = false)
+    private LocalDate productionDate;
+
+    @Column(nullable = false)
+    private String description;
+
+    @OneToMany(mappedBy = "content", cascade = CascadeType.ALL)
+    private List<ContentPaticipant> participants = new ArrayList<>();
+
+    @OneToMany(mappedBy = "content", cascade = CascadeType.ALL)
+    private List<ContentImage> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "content", cascade = CascadeType.ALL)
+    private List<ContentTag> tags = new ArrayList<>();
+
+    public Content(Image posterImage, String mainTitle, String category, LocalDate productionDate, String description) {
+        this.posterImage = posterImage;
+        this.mainTitle = mainTitle;
+        this.category = category;
+        this.productionDate = productionDate;
+        this.description = description;
+    }
+
+    // 연관관계 메서드
+    public void addContentPaticipant(ContentPaticipant contentPaticipant) {
+        this.participants.add(contentPaticipant);
+        contentPaticipant.setContent(this);
+    }
+
+    public void addContentImage(ContentImage contentImage) {
+        this.images.add(contentImage);
+        contentImage.setContent(this);
+    }
+
+    public void addContentTag(ContentTag contentTag) {
+        this.tags.add(contentTag);
+        contentTag.setContent(this);
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/ContentImage.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/ContentImage.java
@@ -1,0 +1,45 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ContentImage {
+
+    @EmbeddedId
+    private ContentImageId id;
+
+    @MapsId("imageId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_id")
+    private Image image;
+
+    @MapsId("contentId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private Content content;
+
+    @Builder
+    public ContentImage(Image image, Content content) {
+        this.id = new ContentImageId(image.getId(), content.getId());
+        this.image = image;
+        this.content = content;
+    }
+
+    public void setContent(Content content) {
+        this.content = content;
+    }
+
+    @Embeddable
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ContentImageId implements Serializable {
+        private Long imageId;
+        private Long contentId;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/ContentPaticipant.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/ContentPaticipant.java
@@ -1,0 +1,52 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ContentPaticipant {
+
+    @EmbeddedId
+    private ContentPaticipantId id;
+
+    @MapsId("participantId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "participant_id")
+    private Participant participant;
+
+    @MapsId("contentId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private Content content;
+
+    @Column(nullable = false)
+    private String role;
+
+    private String charactorName;
+
+    @Builder
+    public ContentPaticipant(Participant participant, Content content, String role, String charactorName) {
+        this.id = new ContentPaticipantId(participant.getId(), content.getId());
+        this.participant = participant;
+        this.content = content;
+        this.role = role;
+        this.charactorName = charactorName;
+    }
+
+    public void setContent(Content content) {
+        this.content = content;
+    }
+
+    @Embeddable
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ContentPaticipantId implements Serializable {
+        private Long participantId;
+        private Long contentId;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/ContentTag.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/ContentTag.java
@@ -1,0 +1,45 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ContentTag {
+
+    @EmbeddedId
+    private ContentTagId id;
+
+    @MapsId("tagId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "image_id")
+    private Tag tag;
+
+    @MapsId("contentId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private Content content;
+
+    @Builder
+    public ContentTag(Tag tag, Content content) {
+        this.id = new ContentTagId(tag.getId(), content.getId());
+        this.tag = tag;
+        this.content = content;
+    }
+
+    public void setContent(Content content) {
+        this.content = content;
+    }
+
+    @Embeddable
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ContentTagId implements Serializable {
+        private Long tagId;
+        private Long contentId;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/Image.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Image.java
@@ -1,0 +1,45 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Image {
+
+    @Id @GeneratedValue
+    @Column(name = "image_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private String originName;
+
+    @Column(nullable = false)
+    private String extention;
+
+    @Column(nullable = false)
+    private String path;
+
+    @Column(nullable = false)
+    private Long size;
+
+    @Builder
+    public Image(String name, String originName, String extention, String path, Long size) {
+        this.name = name;
+        this.originName = originName;
+        this.extention = extention;
+        this.path = path;
+        this.size = size;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/Interest.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Interest.java
@@ -1,0 +1,47 @@
+package com.devpedia.watchapedia.domain;
+
+import com.devpedia.watchapedia.domain.enums.InterestState;
+import com.devpedia.watchapedia.domain.enums.InterestStateConverter;
+import lombok.*;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Interest {
+
+    @EmbeddedId
+    private InterestId id;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @MapsId("contentId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private Content content;
+
+    @Convert(converter = InterestStateConverter.class)
+    @Column(nullable = false)
+    private InterestState score;
+
+    public Interest(User user, Content content, InterestState score) {
+        this.id = new InterestId(user.getId(), content.getId());
+        this.user = user;
+        this.content = content;
+        this.score = score;
+    }
+
+    @Embeddable
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class InterestId implements Serializable {
+        private Long userId;
+        private Long contentId;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/Movie.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Movie.java
@@ -1,0 +1,51 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import java.time.LocalDate;
+
+@Entity
+@DiscriminatorValue("M")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Movie extends Content {
+
+    @Column(nullable = false)
+    private String originTitle;
+
+    @Column(nullable = false)
+    private String countryCode;
+
+    @Column(name = "running_time", nullable = false)
+    private Integer runningTimeInMinutes;
+
+    @Column(name = "watcha_yn", nullable = false)
+    private Boolean isWatchaContent;
+
+    @Column(name = "netflix_yn", nullable = false)
+    private Boolean isNetflixContent;
+
+    private Double bookRate;
+
+    private Long totalAudience;
+
+    @Builder
+    public Movie(Image posterImage, String mainTitle, String category, LocalDate productionDate, String description,
+                 String originTitle, String countryCode, Integer runningTimeInMinutes, Boolean isWatchaContent,
+                 Boolean isNetflixContent, Double bookRate, Long totalAudience) {
+        super(posterImage, mainTitle, category, productionDate, description);
+        this.originTitle = originTitle;
+        this.countryCode = countryCode;
+        this.runningTimeInMinutes = runningTimeInMinutes;
+        this.isWatchaContent = isWatchaContent;
+        this.isNetflixContent = isNetflixContent;
+        this.bookRate = bookRate;
+        this.totalAudience = totalAudience;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/Participant.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Participant.java
@@ -1,0 +1,34 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Participant {
+
+    @Id @GeneratedValue
+    @Column(name = "participant_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "image_id")
+    private Image profileImage;
+
+    private String description;
+
+    @Builder
+    public Participant(String name, Image profileImage, String description) {
+        this.name = name;
+        this.profileImage = profileImage;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/Reply.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Reply.java
@@ -1,0 +1,42 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Reply extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "reply_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumns({
+            @JoinColumn(name = "comment_user_id", referencedColumnName = "user_id"),
+            @JoinColumn(name = "content_id", referencedColumnName = "content_id")
+    })
+    private Comment comment;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reply_user_id", referencedColumnName = "user_id")
+    private User user;
+
+    @Column(nullable = false)
+    private String description;
+
+    public Reply(Comment comment, User user, String description) {
+        this.comment = comment;
+        this.user = user;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/ReplyLike.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/ReplyLike.java
@@ -1,0 +1,41 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReplyLike {
+
+    @EmbeddedId
+    private ReplyLikeId id;
+
+    @MapsId("likeUserId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "like_user_id", referencedColumnName = "user_id")
+    private User user;
+
+    @MapsId("replyId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reply_id")
+    private Reply reply;
+
+    @Builder
+    public ReplyLike(User user, Reply reply) {
+        this.id = new ReplyLikeId(reply.getId(), user.getId());
+        this.user = user;
+        this.reply = reply;
+    }
+
+    @Embeddable
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ReplyLikeId implements Serializable {
+        private Long replyId;
+        private Long likeUserId;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/Score.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Score.java
@@ -1,0 +1,49 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.io.Serializable;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Score {
+
+    @EmbeddedId
+    private ScoreId id;
+
+    @MapsId("userId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @MapsId("contentId")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private Content content;
+
+    @Column(nullable = false)
+    private Double score;
+
+    @Builder
+    public Score(User user, Content content, Double score) {
+        this.id = new ScoreId(user.getId(), content.getId());
+        this.user = user;
+        this.content = content;
+        this.score = score;
+    }
+
+    public void setContent(Content content) {
+        this.content = content;
+    }
+
+    @Embeddable
+    @Data
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ScoreId implements Serializable {
+        private Long userId;
+        private Long contentId;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/Tag.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Tag.java
@@ -1,0 +1,29 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+
+    @Id @GeneratedValue
+    @Column(name = "tag_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String description;
+
+    @Builder
+    public Tag(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/TvShow.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/TvShow.java
@@ -1,0 +1,36 @@
+package com.devpedia.watchapedia.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@DiscriminatorValue("S")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TvShow extends Content {
+
+    @Column(nullable = false)
+    private String originTitle;
+
+    @Column(nullable = false)
+    private String countryCode;
+
+    @Column(name = "watcha_yn", nullable = false)
+    private Boolean isWatchaContent;
+
+    @Column(name = "netflix_yn", nullable = false)
+    private Boolean isNetflixContent;
+
+    public TvShow(Image posterImage, String mainTitle, String category, LocalDate productionDate, String description,
+                  String originTitle, String countryCode, Boolean isWatchaContent, Boolean isNetflixContent) {
+        super(posterImage, mainTitle, category, productionDate, description);
+        this.originTitle = originTitle;
+        this.countryCode = countryCode;
+        this.isWatchaContent = isWatchaContent;
+        this.isNetflixContent = isNetflixContent;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/User.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/User.java
@@ -1,0 +1,86 @@
+package com.devpedia.watchapedia.domain;
+
+import com.devpedia.watchapedia.domain.enums.AccessRange;
+import com.devpedia.watchapedia.domain.enums.AccessRangeConverter;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Where;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Where(clause = "delete_yn = 'N'")
+public class User extends BaseEntity {
+
+    @Id @GeneratedValue
+    @Column(name = "user_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(unique = true, nullable = false)
+    private String email;
+
+    @Column(nullable = false)
+    private String password;
+
+    private String description;
+
+    @Column(nullable = false)
+    private String countryCode;
+
+    @Convert(converter = AccessRangeConverter.class)
+    @Column(nullable = false)
+    private AccessRange accessRange;
+
+    @Column(name = "email_agree_yn", nullable = false)
+    private Boolean isEmailAgreed;
+
+    @Column(name = "sms_agree_yn", nullable = false)
+    private Boolean isSmsAgreed;
+
+    @Column(name = "push_agree_yn", nullable = false)
+    private Boolean isPushAgreed;
+
+    @Column(name = "delete_yn", nullable = false)
+    private Boolean isDeleted;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    private List<String> roles = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Collection> collections = new ArrayList<>();
+
+    @Builder
+    public User(String name, String email, String password, String description, String countryCode, List<String> roles) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.description = description;
+        this.countryCode = countryCode;
+        this.roles = roles;
+        this.accessRange = AccessRange.PUBLIC;
+        this.isEmailAgreed = false;
+        this.isSmsAgreed = false;
+        this.isPushAgreed = false;
+        this.isDeleted = false;
+    }
+
+    // 연관관계 메서드
+    public void addCollection(Collection collection) {
+        this.collections.add(collection);
+        collection.setUser(this);
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/enums/AccessRange.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/enums/AccessRange.java
@@ -1,0 +1,26 @@
+package com.devpedia.watchapedia.domain.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum AccessRange {
+    PUBLIC("모두공개", 1),
+    FRIEND("친구공개", 2),
+    PRIVATE("비공개", 3);
+
+    private String description;
+    private int code;
+
+    public static AccessRange ofCode(int code) {
+        return Arrays.stream(AccessRange.values())
+                .filter(v -> v.getCode() == code)
+                .findAny()
+                // TODO: Add exception
+                .orElseThrow();
+
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/enums/AccessRangeConverter.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/enums/AccessRangeConverter.java
@@ -1,0 +1,17 @@
+package com.devpedia.watchapedia.domain.enums;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter
+public class AccessRangeConverter implements AttributeConverter<AccessRange, Integer> {
+    @Override
+    public Integer convertToDatabaseColumn(AccessRange attribute) {
+        return attribute.getCode();
+    }
+
+    @Override
+    public AccessRange convertToEntityAttribute(Integer dbData) {
+        return AccessRange.ofCode(dbData);
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/enums/BooleanConverter.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/enums/BooleanConverter.java
@@ -1,0 +1,18 @@
+package com.devpedia.watchapedia.domain.enums;
+
+import javax.persistence.AttributeConverter;
+import javax.persistence.Converter;
+
+@Converter(autoApply = true)
+public class BooleanConverter implements AttributeConverter<Boolean, Character> {
+
+    @Override
+    public Character convertToDatabaseColumn(Boolean attribute) {
+        return attribute != null && attribute ? 'Y' : 'N';
+    }
+
+    @Override
+    public Boolean convertToEntityAttribute(Character dbData) {
+        return 'Y' == dbData;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/enums/InterestState.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/enums/InterestState.java
@@ -1,0 +1,26 @@
+package com.devpedia.watchapedia.domain.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+
+@Getter
+@AllArgsConstructor
+public enum InterestState {
+    WISH("보고싶어요", 1),
+    WATCHING("보는중", 2),
+    NOT_INTEREST("관심없음", 3);
+
+    private String description;
+    private int code;
+
+    public static InterestState ofCode(int code) {
+        return Arrays.stream(InterestState.values())
+                .filter(v -> v.getCode() == code)
+                .findAny()
+                // TODO: Add exception
+                .orElseThrow();
+
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/enums/InterestStateConverter.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/enums/InterestStateConverter.java
@@ -1,0 +1,15 @@
+package com.devpedia.watchapedia.domain.enums;
+
+import javax.persistence.AttributeConverter;
+
+public class InterestStateConverter implements AttributeConverter<InterestState, Integer> {
+    @Override
+    public Integer convertToDatabaseColumn(InterestState attribute) {
+        return attribute.getCode();
+    }
+
+    @Override
+    public InterestState convertToEntityAttribute(Integer dbData) {
+        return InterestState.ofCode(dbData);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,1 +1,15 @@
-
+spring:
+  datasource:
+    url: jdbc:mariadb://dbinstance.cveiyepjwzwd.ap-northeast-2.rds.amazonaws.com/main
+    driver-class-name: org.mariadb.jdbc.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        default_batch_fetch_size: 1000
+        format_sql: true
+    open-in-view: false
+logging:
+  level:
+    org.hibernate.SQL: debug


### PR DESCRIPTION
DB ERD 초안을 바탕으로 엔티티 설계(ERD는 Wiki 참조).
비지니스 특성상 역방향 조회할 일이 거의 없으므로 양방향 관계 최소화.
enum은 DB에는 숫자로 저장하므로 Converter와 같이 생성.
생성수정시간이 필요한 엔티티는 BaseEntity 상속.