### PR TITLE
기능추가: 랭킹 엔티티 및 p6spy JDBC SQL 로깅 라이브러리 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'org.apache.httpcomponents:httpclient:4.5.9'
-
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'
 	implementation 'org.apache.commons:commons-lang3:3.9'
 
 	implementation 'io.springfox:springfox-swagger2:2.9.2'

--- a/src/main/java/com/devpedia/watchapedia/controller/BookController.java
+++ b/src/main/java/com/devpedia/watchapedia/controller/BookController.java
@@ -14,6 +14,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -22,13 +24,14 @@ public class BookController {
     private final ContentService contentService;
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "body", value = "Request 객체 json을 body에 담 Content-Type을 application/json로 해야함",
-                    required = true, paramType = "formData")
+            @ApiImplicitParam(name = "body", value = "Models -> BookInsertRequest 참조", required = true)
     })
     @PostMapping(value = "/admin/books", consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     @ResponseStatus(HttpStatus.CREATED)
-    public void addBook(@RequestPart("body") BookDto.BookInsertRequest request, @RequestPart("poster") MultipartFile poster) {
-        contentService.saveBookWithImage(request, poster);
+    public void addBook(@RequestPart("body") BookDto.BookInsertRequest request,
+                        @RequestPart("poster") MultipartFile poster,
+                        @RequestPart(value = "gallery", required = false) List<MultipartFile> gallery) {
+        contentService.saveBookWithImage(request, poster, gallery);
     }
 
 }

--- a/src/main/java/com/devpedia/watchapedia/controller/MovieController.java
+++ b/src/main/java/com/devpedia/watchapedia/controller/MovieController.java
@@ -11,6 +11,8 @@ import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -19,12 +21,13 @@ public class MovieController {
     private final ContentService contentService;
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "body", value = "Request 객체 json을 body에 담 Content-Type을 application/json로 해야함",
-                    required = true, paramType = "formData")
+            @ApiImplicitParam(name = "body", value = "Models -> MovieInsertRequest 참조", required = true)
     })
     @PostMapping(value = "/admin/movies", consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     @ResponseStatus(HttpStatus.CREATED)
-    public void addMovie(@RequestPart("body") MovieDto.MovieInsertRequest request, @RequestPart("poster") MultipartFile poster) {
-        contentService.saveMovieWithImage(request, poster);
+    public void addMovie(@RequestPart("body") MovieDto.MovieInsertRequest request,
+                         @RequestPart("poster") MultipartFile poster,
+                         @RequestPart(value = "gallery", required = false) List<MultipartFile> gallery) {
+        contentService.saveMovieWithImage(request, poster, gallery);
     }
 }

--- a/src/main/java/com/devpedia/watchapedia/controller/TvShowController.java
+++ b/src/main/java/com/devpedia/watchapedia/controller/TvShowController.java
@@ -15,6 +15,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 @Slf4j
 @RestController
 @RequiredArgsConstructor
@@ -23,12 +25,13 @@ public class TvShowController {
     private final ContentService contentService;
 
     @ApiImplicitParams({
-            @ApiImplicitParam(name = "body", value = "Request 객체 json을 body에 담 Content-Type을 application/json로 해야함",
-                    required = true, paramType = "formData")
+            @ApiImplicitParam(name = "body", value = "Models -> TvShowInsertRequest 참조", required = true)
     })
     @PostMapping(value = "/admin/tv_shows", consumes = {MediaType.MULTIPART_MIXED_VALUE, MediaType.MULTIPART_FORM_DATA_VALUE})
     @ResponseStatus(HttpStatus.CREATED)
-    public void addMovie(@RequestPart("body") TvShowDto.TvShowInsertRequest request, @RequestPart("poster") MultipartFile poster) {
-        contentService.saveTvShowWithImage(request, poster);
+    public void addMovie(@RequestPart("body") TvShowDto.TvShowInsertRequest request,
+                         @RequestPart("poster") MultipartFile poster,
+                         @RequestPart(value = "gallery", required = false) List<MultipartFile> gallery) {
+        contentService.saveTvShowWithImage(request, poster, gallery);
     }
 }

--- a/src/main/java/com/devpedia/watchapedia/domain/Book.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Book.java
@@ -22,14 +22,16 @@ public class Book extends Content {
     @Column(nullable = false)
     private Integer page;
 
+    @Column(columnDefinition = "TEXT")
     private String contents;
 
+    @Column(columnDefinition = "TEXT")
     private String elaboration;
 
     @Builder
-    public Book(Image posterImage, String mainTitle, String category, LocalDate productionDate, String descrption,
+    public Book(Image posterImage, String mainTitle, String category, LocalDate productionDate, String description,
                 String subtitle, Integer page, String contents, String elaboration) {
-        super(posterImage, mainTitle, category, productionDate, descrption);
+        super(posterImage, mainTitle, category, productionDate, description);
         this.subtitle = subtitle;
         this.page = page;
         this.contents = contents;

--- a/src/main/java/com/devpedia/watchapedia/domain/Book.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Book.java
@@ -29,9 +29,9 @@ public class Book extends Content {
     private String elaboration;
 
     @Builder
-    public Book(Image posterImage, String mainTitle, String category, LocalDate productionDate, String description,
+    public Book(Ranking ranking,Image posterImage, String mainTitle, String category, LocalDate productionDate, String description,
                 String subtitle, Integer page, String contents, String elaboration) {
-        super(posterImage, mainTitle, category, productionDate, description);
+        super(ranking, posterImage, mainTitle, category, productionDate, description);
         this.subtitle = subtitle;
         this.page = page;
         this.contents = contents;

--- a/src/main/java/com/devpedia/watchapedia/domain/Collection.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Collection.java
@@ -30,7 +30,7 @@ public class Collection extends BaseEntity {
     @Column(nullable = false)
     private String title;
 
-    @Column(nullable = false)
+    @Column(columnDefinition = "TEXT")
     private String description;
 
     @Column(name = "delete_yn", nullable = false)

--- a/src/main/java/com/devpedia/watchapedia/domain/Comment.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Comment.java
@@ -30,7 +30,7 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "content_id")
     private Content content;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String description;
 
     @Column(name = "spoiler_yn", nullable = false)

--- a/src/main/java/com/devpedia/watchapedia/domain/Content.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Content.java
@@ -76,6 +76,15 @@ public abstract class Content {
         this.addContentTag(ct);
     }
 
+    public void addImage(Image image) {
+        if (image == null) return;
+        ContentImage ci = ContentImage.builder()
+                .content(this)
+                .image(image)
+                .build();
+        this.addContentImage(ci);
+    }
+
     // 연관관계 메서드
     public void addContentParticipant(ContentParticipant contentParticipant) {
         this.participants.add(contentParticipant);

--- a/src/main/java/com/devpedia/watchapedia/domain/Content.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Content.java
@@ -56,6 +56,10 @@ public abstract class Content {
         this.description = description;
     }
 
+    public void setPosterImage(Image posterImage) {
+        this.posterImage = posterImage;
+    }
+
     public void addParticipant(Participant participant, String role, String characterName) {
         if (participant == null || role == null || characterName == null) return;
         ContentParticipant cp = ContentParticipant.builder()

--- a/src/main/java/com/devpedia/watchapedia/domain/Content.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Content.java
@@ -24,6 +24,10 @@ public abstract class Content {
     @JoinColumn(name = "image_id")
     private Image posterImage;
 
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "ranking_id")
+    private Ranking ranking;
+
     @Column(nullable = false)
     private String mainTitle;
 
@@ -48,7 +52,8 @@ public abstract class Content {
     @OneToMany(mappedBy = "content", cascade = CascadeType.ALL)
     private List<ContentTag> tags = new ArrayList<>();
 
-    public Content(Image posterImage, String mainTitle, String category, LocalDate productionDate, String description) {
+    public Content(Ranking ranking, Image posterImage, String mainTitle, String category, LocalDate productionDate, String description) {
+        this.ranking = ranking;
         this.posterImage = posterImage;
         this.mainTitle = mainTitle;
         this.category = category;

--- a/src/main/java/com/devpedia/watchapedia/domain/Content.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Content.java
@@ -20,7 +20,7 @@ public abstract class Content {
     @Column(name = "content_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
     @JoinColumn(name = "image_id")
     private Image posterImage;
 
@@ -33,7 +33,7 @@ public abstract class Content {
     @Column(nullable = false)
     private LocalDate productionDate;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String description;
 
     @Column(insertable = false, updatable = false)

--- a/src/main/java/com/devpedia/watchapedia/domain/Content.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Content.java
@@ -20,7 +20,7 @@ public abstract class Content {
     @Column(name = "content_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.EAGER, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "image_id")
     private Image posterImage;
 

--- a/src/main/java/com/devpedia/watchapedia/domain/ContentParticipant.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/ContentParticipant.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"participant_id", "content_id", "role"})})
+@Table(uniqueConstraints = {@UniqueConstraint(columnNames = {"participant_id", "content_id", "role", "characterName"})})
 public class ContentParticipant {
 
     @Id

--- a/src/main/java/com/devpedia/watchapedia/domain/ContentTag.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/ContentTag.java
@@ -15,7 +15,7 @@ public class ContentTag {
 
     @MapsId("tagId")
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "image_id")
+    @JoinColumn(name = "tag_id")
     private Tag tag;
 
     @MapsId("contentId")

--- a/src/main/java/com/devpedia/watchapedia/domain/Interest.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Interest.java
@@ -27,13 +27,13 @@ public class Interest {
 
     @Convert(converter = InterestStateConverter.class)
     @Column(nullable = false)
-    private InterestState score;
+    private InterestState state;
 
-    public Interest(User user, Content content, InterestState score) {
+    public Interest(User user, Content content, InterestState state) {
         this.id = new InterestId(user.getId(), content.getId());
         this.user = user;
         this.content = content;
-        this.score = score;
+        this.state = state;
     }
 
     @Embeddable

--- a/src/main/java/com/devpedia/watchapedia/domain/Movie.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Movie.java
@@ -36,10 +36,10 @@ public class Movie extends Content {
     private Long totalAudience;
 
     @Builder
-    public Movie(Image posterImage, String mainTitle, String category, LocalDate productionDate, String description,
+    public Movie(Ranking ranking,Image posterImage, String mainTitle, String category, LocalDate productionDate, String description,
                  String originTitle, String countryCode, Integer runningTimeInMinutes, Boolean isWatchaContent,
                  Boolean isNetflixContent, Double bookRate, Long totalAudience) {
-        super(posterImage, mainTitle, category, productionDate, description);
+        super(ranking, posterImage, mainTitle, category, productionDate, description);
         this.originTitle = originTitle;
         this.countryCode = countryCode;
         this.runningTimeInMinutes = runningTimeInMinutes;

--- a/src/main/java/com/devpedia/watchapedia/domain/Participant.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Participant.java
@@ -29,6 +29,7 @@ public class Participant {
     @Column(nullable = false)
     private String job;
 
+    @Column(columnDefinition = "TEXT")
     private String description;
 
     @OneToMany(mappedBy = "participant", cascade = CascadeType.ALL)

--- a/src/main/java/com/devpedia/watchapedia/domain/Participant.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Participant.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -25,20 +26,25 @@ public class Participant {
     @JoinColumn(name = "image_id")
     private Image profileImage;
 
+    @Column(nullable = false)
+    private String job;
+
     private String description;
 
     @OneToMany(mappedBy = "participant", cascade = CascadeType.ALL)
     private List<ContentParticipant> contentList = new ArrayList<>();
 
     @Builder
-    public Participant(String name, Image profileImage, String description) {
+    public Participant(String name, Image profileImage, String job, String description) {
         this.name = name;
         this.profileImage = profileImage;
+        this.job = job;
         this.description = description;
     }
 
-    public void updateInfo(String name, String description) {
-        if (name != null && !name.isBlank()) this.name = name;
+    public void updateInfo(String name, String job, String description) {
+        if (name != null && !StringUtils.isBlank(name)) this.name = name;
+        if (job != null && !StringUtils.isBlank(name)) this.job = job;
         if (description != null) this.description = description;
     }
 }

--- a/src/main/java/com/devpedia/watchapedia/domain/Ranking.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Ranking.java
@@ -1,0 +1,50 @@
+package com.devpedia.watchapedia.domain;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Ranking {
+    @Id @GeneratedValue
+    @Column(name = "ranking_id")
+    private Long id;
+
+    /**
+     * 차트 랭킹 (1~30)
+     */
+    @Column(nullable = false)
+    private Long chart_rank;
+
+    /**
+     * 영화: M, TV 프로그램: T,  책: B
+     */
+    @Column(nullable = false)
+    private String chart_type;
+
+    /**
+     * box_office:박스오피스, mars:왓챠, netflix: 넷플릭스, predicted_rating: 별점, person:감독, person:배우, tag_match:태그, deck:컬렉션, deck_all: 모든컬렉션
+     */
+    @Column(nullable = false)
+    private String chart_id;
+
+    /**
+     * 콘텐츠 리스트
+     */
+    @OneToMany(mappedBy = "ranking", fetch = FetchType.LAZY)
+    private List<Content> rankingContentList = new ArrayList<>();
+
+    public Ranking(Long chart_rank, String chart_type, String chart_id, List<Content> rankingContentList){
+        this.chart_rank = chart_rank;
+        this.chart_type = chart_type;
+        this.chart_id = chart_id;
+        this.rankingContentList = rankingContentList;
+    }
+
+
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/Reply.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Reply.java
@@ -31,7 +31,7 @@ public class Reply extends BaseEntity {
     @JoinColumn(name = "reply_user_id", referencedColumnName = "user_id")
     private User user;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String description;
 
     public Reply(Comment comment, User user, String description) {

--- a/src/main/java/com/devpedia/watchapedia/domain/TvShow.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/TvShow.java
@@ -27,9 +27,9 @@ public class TvShow extends Content {
     private Boolean isNetflixContent;
 
     @Builder
-    public TvShow(Image posterImage, String mainTitle, String category, LocalDate productionDate, String description,
+    public TvShow(Ranking ranking,Image posterImage, String mainTitle, String category, LocalDate productionDate, String description,
                   String originTitle, String countryCode, Boolean isWatchaContent, Boolean isNetflixContent) {
-        super(posterImage, mainTitle, category, productionDate, description);
+        super(ranking, posterImage, mainTitle, category, productionDate, description);
         this.originTitle = originTitle;
         this.countryCode = countryCode;
         this.isWatchaContent = isWatchaContent;

--- a/src/main/java/com/devpedia/watchapedia/domain/User.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/User.java
@@ -36,6 +36,7 @@ public class User extends BaseEntity {
     @Column(nullable = false)
     private String password;
 
+    @Column(columnDefinition = "TEXT")
     private String description;
 
     @Column(nullable = false)

--- a/src/main/java/com/devpedia/watchapedia/domain/enums/BooleanConverter.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/enums/BooleanConverter.java
@@ -13,6 +13,6 @@ public class BooleanConverter implements AttributeConverter<Boolean, Character> 
 
     @Override
     public Boolean convertToEntityAttribute(Character dbData) {
-        return 'Y' == dbData;
+        return dbData != null && dbData == 'Y';
     }
 }

--- a/src/main/java/com/devpedia/watchapedia/domain/enums/ImageCategory.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/enums/ImageCategory.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 public enum ImageCategory {
     POSTER("poster"),
     PARTICIPANT_PROFILE("pprofile"),
-    USER_PROFILE("uprofile");
+    USER_PROFILE("uprofile"),
+    GALLERY("gallery");
 
     private final String directory;
 }

--- a/src/main/java/com/devpedia/watchapedia/dto/BookDto.java
+++ b/src/main/java/com/devpedia/watchapedia/dto/BookDto.java
@@ -42,7 +42,7 @@ public class BookDto {
                     .mainTitle(this.mainTitle)
                     .subtitle(this.subtitle)
                     .category(this.category)
-                    .descrption(this.description)
+                    .description(this.description)
                     .productionDate(this.productionDate)
                     .page(this.page)
                     .elaboration(this.elaboration)

--- a/src/main/java/com/devpedia/watchapedia/dto/BookDto.java
+++ b/src/main/java/com/devpedia/watchapedia/dto/BookDto.java
@@ -1,5 +1,6 @@
 package com.devpedia.watchapedia.dto;
 
+import com.devpedia.watchapedia.domain.Book;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
@@ -34,5 +35,19 @@ public class BookDto {
         private List<ParticipantDto.ParticipantRole> roles;
 
         private List<Long> tags;
+
+        public Book toEntity() {
+            return Book.builder()
+                    .posterImage(null)
+                    .mainTitle(this.mainTitle)
+                    .subtitle(this.subtitle)
+                    .category(this.category)
+                    .descrption(this.description)
+                    .productionDate(this.productionDate)
+                    .page(this.page)
+                    .elaboration(this.elaboration)
+                    .contents(this.contents)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/devpedia/watchapedia/dto/ContentDto.java
+++ b/src/main/java/com/devpedia/watchapedia/dto/ContentDto.java
@@ -1,9 +1,13 @@
 package com.devpedia.watchapedia.dto;
 
+import com.devpedia.watchapedia.domain.Content;
+import com.devpedia.watchapedia.util.UrlUtil;
 import lombok.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.constraints.NotBlank;
 import java.time.LocalDate;
+import java.util.List;
 
 public class ContentDto {
     @Getter
@@ -22,5 +26,24 @@ public class ContentDto {
         private LocalDate productionDate;
 
         private String posterImagePath;
+
+        public CommonContentInfo(Content content) {
+            this.id = content.getId();
+            this.contentType = content.getDtype();
+            this.mainTitle = content.getMainTitle();
+            this.productionDate = content.getProductionDate();
+            this.posterImagePath = UrlUtil.getCloudFrontUrl(content.getPosterImage().getPath());
+        }
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class ContentChildren {
+        private List<ParticipantDto.ParticipantRole> roles;
+        private List<Long> tags;
+        private List<MultipartFile> gallery;
     }
 }

--- a/src/main/java/com/devpedia/watchapedia/dto/MovieDto.java
+++ b/src/main/java/com/devpedia/watchapedia/dto/MovieDto.java
@@ -1,5 +1,7 @@
 package com.devpedia.watchapedia.dto;
 
+import com.devpedia.watchapedia.domain.Image;
+import com.devpedia.watchapedia.domain.Movie;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
@@ -41,5 +43,22 @@ public class MovieDto {
         private List<ParticipantDto.ParticipantRole> roles;
 
         private List<Long> tags;
+
+        public Movie toEntity() {
+            return Movie.builder()
+                    .posterImage(null)
+                    .mainTitle(this.mainTitle)
+                    .category(this.category)
+                    .description(this.description)
+                    .productionDate(this.productionDate)
+                    .countryCode(this.countryCode)
+                    .originTitle(this.originTitle)
+                    .runningTimeInMinutes(this.runningTimeInMinutes)
+                    .bookRate(this.bookRate)
+                    .totalAudience(this.totalAudience)
+                    .isNetflixContent(this.isNetflixContent)
+                    .isWatchaContent(this.isWatchaContent)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/devpedia/watchapedia/dto/ParticipantDto.java
+++ b/src/main/java/com/devpedia/watchapedia/dto/ParticipantDto.java
@@ -1,5 +1,8 @@
 package com.devpedia.watchapedia.dto;
 
+import com.devpedia.watchapedia.domain.Image;
+import com.devpedia.watchapedia.domain.Participant;
+import com.devpedia.watchapedia.util.UrlUtil;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
@@ -18,6 +21,15 @@ public class ParticipantDto {
         private String job;
 
         private String description;
+
+        public Participant toEntity(Image profileImage) {
+            return Participant.builder()
+                    .profileImage(profileImage)
+                    .name(this.name)
+                    .job(this.job)
+                    .description(this.description)
+                    .build();
+        }
     }
 
     @Getter
@@ -61,6 +73,15 @@ public class ParticipantDto {
         private String description;
 
         private String profileImagePath;
+
+        public ParticipantInfo(Participant participant) {
+            this.id = participant.getId();
+            this.name = participant.getName();
+            this.job = participant.getJob();
+            this.description = participant.getDescription();
+            this.profileImagePath = participant.getProfileImage() != null
+                    ? UrlUtil.getCloudFrontUrl(participant.getProfileImage().getPath()) : null;
+        }
     }
 
 

--- a/src/main/java/com/devpedia/watchapedia/dto/ParticipantDto.java
+++ b/src/main/java/com/devpedia/watchapedia/dto/ParticipantDto.java
@@ -14,6 +14,8 @@ public class ParticipantDto {
     public static class ParticipantInsertRequest {
         @NotBlank
         private String name;
+        @NotBlank
+        private String job;
 
         private String description;
     }
@@ -25,6 +27,7 @@ public class ParticipantDto {
     @Builder
     public static class ParticipantUpdateRequest {
         private String name;
+        private String job;
         private String description;
     }
 
@@ -52,6 +55,8 @@ public class ParticipantDto {
         private Long id;
         @NotBlank
         private String name;
+        @NotBlank
+        private String job;
 
         private String description;
 

--- a/src/main/java/com/devpedia/watchapedia/dto/TagDto.java
+++ b/src/main/java/com/devpedia/watchapedia/dto/TagDto.java
@@ -1,5 +1,6 @@
 package com.devpedia.watchapedia.dto;
 
+import com.devpedia.watchapedia.domain.Tag;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
@@ -25,5 +26,10 @@ public class TagDto {
         private Long id;
         @NotBlank
         private String description;
+
+        public TagInfo(Tag tag) {
+            this.id = tag.getId();
+            this.description = tag.getDescription();
+        }
     }
 }

--- a/src/main/java/com/devpedia/watchapedia/dto/TvShowDto.java
+++ b/src/main/java/com/devpedia/watchapedia/dto/TvShowDto.java
@@ -1,5 +1,7 @@
 package com.devpedia.watchapedia.dto;
 
+import com.devpedia.watchapedia.domain.Image;
+import com.devpedia.watchapedia.domain.TvShow;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
@@ -34,5 +36,19 @@ public class TvShowDto {
         private List<ParticipantDto.ParticipantRole> roles;
 
         private List<Long> tags;
+
+        public TvShow toEntity() {
+            return TvShow.builder()
+                    .posterImage(null)
+                    .mainTitle(this.mainTitle)
+                    .category(this.category)
+                    .description(this.description)
+                    .productionDate(this.productionDate)
+                    .countryCode(this.countryCode)
+                    .originTitle(this.originTitle)
+                    .isNetflixContent(this.isNetflixContent)
+                    .isWatchaContent(this.isWatchaContent)
+                    .build();
+        }
     }
 }

--- a/src/main/java/com/devpedia/watchapedia/dto/UserDto.java
+++ b/src/main/java/com/devpedia/watchapedia/dto/UserDto.java
@@ -1,5 +1,6 @@
 package com.devpedia.watchapedia.dto;
 
+import com.devpedia.watchapedia.domain.User;
 import com.devpedia.watchapedia.domain.enums.AccessRange;
 import com.fasterxml.jackson.annotation.JsonFilter;
 import lombok.*;
@@ -88,6 +89,18 @@ public class UserDto {
         private Boolean isPushAgreed;
         @NotNull
         private List<String> roles;
+
+        public UserInfo(User user) {
+            this.name = user.getName();
+            this.email = user.getEmail();
+            this.countryCode = user.getCountryCode();
+            this.description = user.getDescription();
+            this.isEmailAgreed = user.getIsEmailAgreed();
+            this.isSmsAgreed = user.getIsSmsAgreed();
+            this.isPushAgreed = user.getIsPushAgreed();
+            this.accessRange = user.getAccessRange();
+            this.roles = user.getRoles();
+        }
     }
 
     @Getter @Setter
@@ -102,6 +115,13 @@ public class UserDto {
         private String email;
 
         private List<String> roles;
+
+        public UserInfoMinimum(User user) {
+            this.id = user.getId();
+            this.name = user.getName();
+            this.email = user.getEmail();
+            this.roles = user.getRoles();
+        }
     }
 
     @Getter @Setter

--- a/src/main/java/com/devpedia/watchapedia/exception/InvalidFileException.java
+++ b/src/main/java/com/devpedia/watchapedia/exception/InvalidFileException.java
@@ -1,0 +1,10 @@
+package com.devpedia.watchapedia.exception;
+
+import com.devpedia.watchapedia.exception.common.BusinessException;
+import com.devpedia.watchapedia.exception.common.ErrorCode;
+
+public class InvalidFileException extends BusinessException {
+    public InvalidFileException(ErrorCode errorCode, String message) {
+        super(errorCode, message);
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/exception/common/ErrorCode.java
+++ b/src/main/java/com/devpedia/watchapedia/exception/common/ErrorCode.java
@@ -19,7 +19,8 @@ public enum ErrorCode {
     ENTITY_NOT_FOUND(BAD_REQUEST, "C003", "해당 엔티티가 존재하지 않습니다"),
     PASSWORD_NOT_MATCH(BAD_REQUEST, "C004", "비밀번호가 일치하지 않습니다"),
     TOKEN_INVALID(UNAUTHORIZED, "C005", "유효하지 않은 토큰입니다"),
-    USER_ON_DELETE(BAD_REQUEST, "C006", "삭제 유예기간인 회원입니다");
+    USER_ON_DELETE(BAD_REQUEST, "C006", "삭제 유예기간인 회원입니다"),
+    IMAGE_FORMAT_INVALID(BAD_REQUEST, "C007", "올바르지 않은 이미지 파일입니다");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/devpedia/watchapedia/exception/handler/BusinessExceptionHandler.java
+++ b/src/main/java/com/devpedia/watchapedia/exception/handler/BusinessExceptionHandler.java
@@ -1,9 +1,6 @@
 package com.devpedia.watchapedia.exception.handler;
 
-import com.devpedia.watchapedia.exception.EntityNotExistException;
-import com.devpedia.watchapedia.exception.ExternalIOException;
-import com.devpedia.watchapedia.exception.ValueDuplicatedException;
-import com.devpedia.watchapedia.exception.ValueNotMatchException;
+import com.devpedia.watchapedia.exception.*;
 import com.devpedia.watchapedia.exception.common.ErrorResponse;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
@@ -36,4 +33,11 @@ public class BusinessExceptionHandler {
         ErrorResponse response = ErrorResponse.from(e);
         return new ResponseEntity<>(response, response.getStatus());
     }
+
+    @ExceptionHandler(InvalidFileException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(InvalidFileException e) {
+        ErrorResponse response = ErrorResponse.from(e);
+        return new ResponseEntity<>(response, response.getStatus());
+    }
+
 }

--- a/src/main/java/com/devpedia/watchapedia/exception/handler/CommonExceptionHandler.java
+++ b/src/main/java/com/devpedia/watchapedia/exception/handler/CommonExceptionHandler.java
@@ -5,10 +5,12 @@ import com.devpedia.watchapedia.exception.common.ErrorResponse;
 import io.jsonwebtoken.JwtException;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import javax.validation.ConstraintViolationException;
 
@@ -36,6 +38,18 @@ public class CommonExceptionHandler {
     @ExceptionHandler(MissingRequestHeaderException.class)
     protected ResponseEntity<ErrorResponse> handleBindException(MissingRequestHeaderException e) {
         ErrorResponse response = ErrorResponse.of(ErrorCode.INPUT_VALUE_INVALID, e.getMessage());
+        return new ResponseEntity<>(response, response.getStatus());
+    }
+
+    @ExceptionHandler(MissingServletRequestPartException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(MissingServletRequestPartException e) {
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INPUT_VALUE_INVALID, e.getMessage());
+        return new ResponseEntity<>(response, response.getStatus());
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(HttpMessageNotReadableException e) {
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INPUT_VALUE_INVALID);
         return new ResponseEntity<>(response, response.getStatus());
     }
 }

--- a/src/main/java/com/devpedia/watchapedia/service/ContentService.java
+++ b/src/main/java/com/devpedia/watchapedia/service/ContentService.java
@@ -6,7 +6,6 @@ import com.devpedia.watchapedia.dto.*;
 import com.devpedia.watchapedia.exception.InvalidFileException;
 import com.devpedia.watchapedia.exception.common.ErrorCode;
 import com.devpedia.watchapedia.repository.*;
-import com.devpedia.watchapedia.util.UrlUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -30,78 +29,38 @@ public class ContentService {
     private final TagRepository tagRepository;
 
     public void saveBookWithImage(BookDto.BookInsertRequest request, MultipartFile poster, List<MultipartFile> gallery) {
-        if (isInvalidImageFile(poster))
-            throw new InvalidFileException(ErrorCode.IMAGE_FORMAT_INVALID, "포스터 이미지 파일이 올바르지 않습니다");
-
-        Image posterImage = Image.of(poster, ImageCategory.POSTER);
-        s3Service.upload(poster, posterImage.getPath());
-
-        Book book = Book.builder()
-                .posterImage(posterImage)
-                .mainTitle(request.getMainTitle())
-                .subtitle(request.getSubtitle())
-                .category(request.getCategory())
-                .descrption(request.getDescription())
-                .productionDate(request.getProductionDate())
-                .page(request.getPage())
-                .elaboration(request.getElaboration())
-                .contents(request.getContents())
-                .build();
-
-        addChildren(book, request.getRoles(), request.getTags(), gallery);
-
-        contentRepository.save(book);
+        Book book = request.toEntity();
+        createContent(book, poster, new ContentDto.ContentChildren(request.getRoles(), request.getTags(), gallery));
     }
 
     public void saveMovieWithImage(MovieDto.MovieInsertRequest request, MultipartFile poster, List<MultipartFile> gallery) {
-        if (isInvalidImageFile(poster))
-            throw new InvalidFileException(ErrorCode.IMAGE_FORMAT_INVALID, "포스터 이미지 파일이 올바르지 않습니다");
-
-        Image posterImage = Image.of(poster, ImageCategory.POSTER);
-        s3Service.upload(poster, posterImage.getPath());
-
-        Movie movie = Movie.builder()
-                .posterImage(posterImage)
-                .mainTitle(request.getMainTitle())
-                .category(request.getCategory())
-                .description(request.getDescription())
-                .productionDate(request.getProductionDate())
-                .countryCode(request.getCountryCode())
-                .originTitle(request.getOriginTitle())
-                .runningTimeInMinutes(request.getRunningTimeInMinutes())
-                .bookRate(request.getBookRate())
-                .totalAudience(request.getTotalAudience())
-                .isNetflixContent(request.getIsNetflixContent())
-                .isWatchaContent(request.getIsWatchaContent())
-                .build();
-
-        addChildren(movie, request.getRoles(), request.getTags(), gallery);
-
-        contentRepository.save(movie);
+        Movie movie = request.toEntity();
+        createContent(movie, poster, new ContentDto.ContentChildren(request.getRoles(), request.getTags(), gallery));
     }
 
     public void saveTvShowWithImage(TvShowDto.TvShowInsertRequest request, MultipartFile poster, List<MultipartFile> gallery) {
+        TvShow tvShow = request.toEntity();
+        createContent(tvShow, poster, new ContentDto.ContentChildren(request.getRoles(), request.getTags(), gallery));
+    }
+
+    private void createContent(Content content, MultipartFile poster, ContentDto.ContentChildren children) {
+        addPosterImage(content, poster);
+        addChildren(content, children.getRoles(), children.getTags(), children.getGallery());
+    }
+
+    private void addPosterImage(Content content, MultipartFile poster) {
+        Image posterImage = createPosterImage(poster);
+        content.setPosterImage(posterImage);
+    }
+
+    private Image createPosterImage(MultipartFile poster) {
         if (isInvalidImageFile(poster))
             throw new InvalidFileException(ErrorCode.IMAGE_FORMAT_INVALID, "포스터 이미지 파일이 올바르지 않습니다");
 
         Image posterImage = Image.of(poster, ImageCategory.POSTER);
         s3Service.upload(poster, posterImage.getPath());
 
-        TvShow tvShow = TvShow.builder()
-                .posterImage(posterImage)
-                .mainTitle(request.getMainTitle())
-                .category(request.getCategory())
-                .description(request.getDescription())
-                .productionDate(request.getProductionDate())
-                .countryCode(request.getCountryCode())
-                .originTitle(request.getOriginTitle())
-                .isNetflixContent(request.getIsNetflixContent())
-                .isWatchaContent(request.getIsWatchaContent())
-                .build();
-
-        addChildren(tvShow, request.getRoles(), request.getTags(), gallery);
-
-        contentRepository.save(tvShow);
+        return posterImage;
     }
 
     private void addChildren(Content content, List<ParticipantDto.ParticipantRole> roles, List<Long> tags, List<MultipartFile> gallery) {
@@ -155,13 +114,7 @@ public class ContentService {
         List<Content> list = contentRepository.searchWithPaging(Content.class, query, page, size);
 
         return list.stream()
-                .map(content -> ContentDto.CommonContentInfo.builder()
-                        .id(content.getId())
-                        .contentType(content.getDtype())
-                        .mainTitle(content.getMainTitle())
-                        .productionDate(content.getProductionDate())
-                        .posterImagePath(UrlUtil.getCloudFrontUrl(content.getPosterImage().getPath()))
-                        .build())
+                .map(ContentDto.CommonContentInfo::new)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/devpedia/watchapedia/service/ContentService.java
+++ b/src/main/java/com/devpedia/watchapedia/service/ContentService.java
@@ -3,9 +3,12 @@ package com.devpedia.watchapedia.service;
 import com.devpedia.watchapedia.domain.*;
 import com.devpedia.watchapedia.domain.enums.ImageCategory;
 import com.devpedia.watchapedia.dto.*;
+import com.devpedia.watchapedia.exception.InvalidFileException;
+import com.devpedia.watchapedia.exception.common.ErrorCode;
 import com.devpedia.watchapedia.repository.*;
 import com.devpedia.watchapedia.util.UrlUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -16,6 +19,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
+@Slf4j
 @Transactional
 @RequiredArgsConstructor
 public class ContentService {
@@ -25,9 +29,11 @@ public class ContentService {
     private final ParticipantRepository participantRepository;
     private final TagRepository tagRepository;
 
-    public void saveBookWithImage(BookDto.BookInsertRequest request, MultipartFile poster) {
-        Image posterImage = Image.of(poster, ImageCategory.POSTER);
+    public void saveBookWithImage(BookDto.BookInsertRequest request, MultipartFile poster, List<MultipartFile> gallery) {
+        if (isInvalidImageFile(poster))
+            throw new InvalidFileException(ErrorCode.IMAGE_FORMAT_INVALID, "포스터 이미지 파일이 올바르지 않습니다");
 
+        Image posterImage = Image.of(poster, ImageCategory.POSTER);
         s3Service.upload(poster, posterImage.getPath());
 
         Book book = Book.builder()
@@ -42,14 +48,16 @@ public class ContentService {
                 .contents(request.getContents())
                 .build();
 
-        addParticipantsAndTags(book, request.getRoles(), request.getTags());
+        addChildren(book, request.getRoles(), request.getTags(), gallery);
 
         contentRepository.save(book);
     }
 
-    public void saveMovieWithImage(MovieDto.MovieInsertRequest request, MultipartFile poster) {
-        Image posterImage = Image.of(poster, ImageCategory.POSTER);
+    public void saveMovieWithImage(MovieDto.MovieInsertRequest request, MultipartFile poster, List<MultipartFile> gallery) {
+        if (isInvalidImageFile(poster))
+            throw new InvalidFileException(ErrorCode.IMAGE_FORMAT_INVALID, "포스터 이미지 파일이 올바르지 않습니다");
 
+        Image posterImage = Image.of(poster, ImageCategory.POSTER);
         s3Service.upload(poster, posterImage.getPath());
 
         Movie movie = Movie.builder()
@@ -67,14 +75,16 @@ public class ContentService {
                 .isWatchaContent(request.getIsWatchaContent())
                 .build();
 
-        addParticipantsAndTags(movie, request.getRoles(), request.getTags());
+        addChildren(movie, request.getRoles(), request.getTags(), gallery);
 
         contentRepository.save(movie);
     }
 
-    public void saveTvShowWithImage(TvShowDto.TvShowInsertRequest request, MultipartFile poster) {
-        Image posterImage = Image.of(poster, ImageCategory.POSTER);
+    public void saveTvShowWithImage(TvShowDto.TvShowInsertRequest request, MultipartFile poster, List<MultipartFile> gallery) {
+        if (isInvalidImageFile(poster))
+            throw new InvalidFileException(ErrorCode.IMAGE_FORMAT_INVALID, "포스터 이미지 파일이 올바르지 않습니다");
 
+        Image posterImage = Image.of(poster, ImageCategory.POSTER);
         s3Service.upload(poster, posterImage.getPath());
 
         TvShow tvShow = TvShow.builder()
@@ -89,14 +99,15 @@ public class ContentService {
                 .isWatchaContent(request.getIsWatchaContent())
                 .build();
 
-        addParticipantsAndTags(tvShow, request.getRoles(), request.getTags());
+        addChildren(tvShow, request.getRoles(), request.getTags(), gallery);
 
         contentRepository.save(tvShow);
     }
 
-    private void addParticipantsAndTags(Content content, List<ParticipantDto.ParticipantRole> roles, List<Long> tags) {
+    private void addChildren(Content content, List<ParticipantDto.ParticipantRole> roles, List<Long> tags, List<MultipartFile> gallery) {
         addParticipants(content, roles);
         addTags(content, tags);
+        addGallery(content, gallery);
     }
 
     private void addParticipants(Content content, List<ParticipantDto.ParticipantRole> roles) {
@@ -121,6 +132,23 @@ public class ContentService {
         for (Tag tag : addedTags) {
             content.addTag(tag);
         }
+    }
+
+    private void addGallery(Content content, List<MultipartFile> gallery) {
+        if (content == null || gallery == null) return;
+
+        for (MultipartFile file : gallery) {
+            if (isInvalidImageFile(file)) continue;
+            Image galleryImage = Image.of(file, ImageCategory.GALLERY);
+            s3Service.upload(file, galleryImage.getPath());
+
+            content.addImage(galleryImage);
+        }
+    }
+
+    private boolean isInvalidImageFile(MultipartFile file) {
+        return file.isEmpty() || file.getSize() == 0 ||
+                file.getContentType() == null || !file.getContentType().contains("image");
     }
 
     public List<ContentDto.CommonContentInfo> searchAllWithPaging(String query, int page, int size) {

--- a/src/main/java/com/devpedia/watchapedia/service/ContentService.java
+++ b/src/main/java/com/devpedia/watchapedia/service/ContentService.java
@@ -46,6 +46,7 @@ public class ContentService {
     private void createContent(Content content, MultipartFile poster, ContentDto.ContentChildren children) {
         addPosterImage(content, poster);
         addChildren(content, children.getRoles(), children.getTags(), children.getGallery());
+        contentRepository.save(content);
     }
 
     private void addPosterImage(Content content, MultipartFile poster) {

--- a/src/main/java/com/devpedia/watchapedia/service/ParticipantService.java
+++ b/src/main/java/com/devpedia/watchapedia/service/ParticipantService.java
@@ -28,7 +28,7 @@ public class ParticipantService {
         Image profileImage = null;
 
         if (profile != null && !profile.isEmpty()) {
-            profileImage = Image.of(profile, ImageCategory.POSTER);
+            profileImage = Image.of(profile, ImageCategory.PARTICIPANT_PROFILE);
             s3Service.upload(profile, profileImage.getPath());
         }
 

--- a/src/main/java/com/devpedia/watchapedia/service/ParticipantService.java
+++ b/src/main/java/com/devpedia/watchapedia/service/ParticipantService.java
@@ -34,6 +34,7 @@ public class ParticipantService {
 
         Participant participant = Participant.builder()
                 .name(request.getName())
+                .job(request.getJob())
                 .description(request.getDescription())
                 .profileImage(profileImage)
                 .build();
@@ -48,6 +49,7 @@ public class ParticipantService {
                 .map(participant -> ParticipantDto.ParticipantInfo.builder()
                         .id(participant.getId())
                         .name(participant.getName())
+                        .job(participant.getJob())
                         .description(participant.getDescription())
                         .profileImagePath(
                                 participant.getProfileImage() != null
@@ -59,7 +61,7 @@ public class ParticipantService {
     public void update(Long participantId, ParticipantDto.ParticipantUpdateRequest request) {
         Participant participant = participantRepository.findById(participantId);
         if (participant == null) throw new EntityNotExistException(ErrorCode.ENTITY_NOT_FOUND);
-        participant.updateInfo(request.getName(), request.getDescription());
+        participant.updateInfo(request.getName(), request.getJob(), request.getDescription());
     }
 
     public void delete(Long id) {

--- a/src/main/java/com/devpedia/watchapedia/service/ParticipantService.java
+++ b/src/main/java/com/devpedia/watchapedia/service/ParticipantService.java
@@ -32,12 +32,7 @@ public class ParticipantService {
             s3Service.upload(profile, profileImage.getPath());
         }
 
-        Participant participant = Participant.builder()
-                .name(request.getName())
-                .job(request.getJob())
-                .description(request.getDescription())
-                .profileImage(profileImage)
-                .build();
+        Participant participant = request.toEntity(profileImage);
 
         participantRepository.save(participant);
     }
@@ -46,15 +41,7 @@ public class ParticipantService {
         List<Participant> list = participantRepository.searchWithPaging(query, page, size);
 
         return list.stream()
-                .map(participant -> ParticipantDto.ParticipantInfo.builder()
-                        .id(participant.getId())
-                        .name(participant.getName())
-                        .job(participant.getJob())
-                        .description(participant.getDescription())
-                        .profileImagePath(
-                                participant.getProfileImage() != null
-                                        ? UrlUtil.getCloudFrontUrl(participant.getProfileImage().getPath()) : null)
-                        .build())
+                .map(ParticipantDto.ParticipantInfo::new)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/devpedia/watchapedia/service/TagService.java
+++ b/src/main/java/com/devpedia/watchapedia/service/TagService.java
@@ -36,10 +36,7 @@ public class TagService {
         List<Tag> list = tagRepository.searchWithPaging(query, page, size);
 
         return list.stream()
-                .map(tag -> TagDto.TagInfo.builder()
-                        .id(tag.getId())
-                        .description(tag.getDescription())
-                        .build())
+                .map(TagDto.TagInfo::new)
                 .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/devpedia/watchapedia/service/UserService.java
+++ b/src/main/java/com/devpedia/watchapedia/service/UserService.java
@@ -68,6 +68,7 @@ public class UserService {
                 .name(name)
                 .countryCode("KR")
                 .build();
+
         userRepository.save(user);
     }
 
@@ -92,17 +93,7 @@ public class UserService {
 
     public UserDto.UserInfo getUserInfo(Long id) {
         User user = getUserIfExistOrThrow(id);
-        return UserDto.UserInfo.builder()
-                .name(user.getName())
-                .email(user.getEmail())
-                .countryCode(user.getCountryCode())
-                .description(user.getDescription())
-                .isEmailAgreed(user.getIsEmailAgreed())
-                .isPushAgreed(user.getIsPushAgreed())
-                .isSmsAgreed(user.getIsSmsAgreed())
-                .accessRange(user.getAccessRange())
-                .roles(user.getRoles())
-                .build();
+        return new UserDto.UserInfo(user);
     }
 
     public void editUserInfo(Long id, UserDto.UserInfoEditRequest userInfo) {
@@ -143,12 +134,7 @@ public class UserService {
     public List<UserDto.UserInfoMinimum> getAllUserInfo() {
         List<User> list = userRepository.findAll();
         return list.stream()
-                .map(user -> UserDto.UserInfoMinimum.builder()
-                        .id(user.getId())
-                        .name(user.getName())
-                        .email(user.getEmail())
-                        .roles(user.getRoles())
-                        .build())
+                .map(UserDto.UserInfoMinimum::new)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,8 @@ spring:
     host: 222.111.195.42
   servlet:
     multipart:
-      max-file-size: 3MB
+      max-file-size: 2MB
+      max-request-size: 15MB
 
 cloud:
   aws:
@@ -34,4 +35,5 @@ cloud:
 logging:
   level:
     com.devpedia.watchapedia.controller: debug
+    com.devpedia.watchapedia.service: debug
     org.hibernate.SQL: debug

--- a/src/test/java/com/devpedia/watchapedia/repository/ContentRepositoryTest.java
+++ b/src/test/java/com/devpedia/watchapedia/repository/ContentRepositoryTest.java
@@ -217,7 +217,7 @@ class ContentRepositoryTest {
                 .mainTitle("book")
                 .subtitle("sub")
                 .category("romance")
-                .descrption("desc")
+                .description("desc")
                 .productionDate(LocalDate.of(2020, 1, 20))
                 .page(2000)
                 .elaboration("el")

--- a/src/test/java/com/devpedia/watchapedia/repository/ParticipantRepositoryTest.java
+++ b/src/test/java/com/devpedia/watchapedia/repository/ParticipantRepositoryTest.java
@@ -49,16 +49,19 @@ class ParticipantRepositoryTest {
         // given
         Participant expected1 = Participant.builder()
                 .name("p1")
+                .job("j1")
                 .description("desc1")
                 .build();
 
         Participant expected2 = Participant.builder()
                 .name("p2")
+                .job("j2")
                 .description("desc2")
                 .build();
 
         Participant expected3 = Participant.builder()
                 .name("p3")
+                .job("j3")
                 .description("desc3")
                 .build();
 
@@ -92,16 +95,19 @@ class ParticipantRepositoryTest {
         // given
         Participant expected1 = Participant.builder()
                 .name("aaa")
+                .job("j1")
                 .description("desc1")
                 .build();
 
         Participant expected2 = Participant.builder()
                 .name("bbb")
+                .job("j2")
                 .description("desc2")
                 .build();
 
         Participant expected3 = Participant.builder()
                 .name("aab")
+                .job("j3")
                 .description("desc2")
                 .build();
 
@@ -121,16 +127,19 @@ class ParticipantRepositoryTest {
         // given
         Participant expected1 = Participant.builder()
                 .name("aaa")
+                .job("j1")
                 .description("desc1")
                 .build();
 
         Participant expected2 = Participant.builder()
                 .name("bbb")
+                .job("j2")
                 .description("desc2")
                 .build();
 
         Participant expected3 = Participant.builder()
                 .name("aab")
+                .job("j3")
                 .description("desc2")
                 .build();
 

--- a/src/test/java/com/devpedia/watchapedia/service/ContentServiceTest.java
+++ b/src/test/java/com/devpedia/watchapedia/service/ContentServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDate;
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -64,7 +65,10 @@ class ContentServiceTest {
                 .tags(Collections.singletonList(1L))
                 .build();
 
-        MultipartFile file = new MockMultipartFile("image.jpg", new byte[100]);
+        MultipartFile poster = new MockMultipartFile("poster.jpg", "poster.jpg", "image/jpg", new byte[100]);
+        List<MultipartFile> gallery = Collections.singletonList(
+                new MockMultipartFile("gallery.jpg", "gallery.jpg", "image/jpg", new byte[100])
+        );
 
         given(participantRepository.findListIn(anySet()))
                 .willReturn(Collections.singletonList(participant));
@@ -74,10 +78,11 @@ class ContentServiceTest {
         given(tag.getId()).willReturn(1L);
 
         // when
-        contentService.saveBookWithImage(request, file);
+        contentService.saveBookWithImage(request, poster, gallery);
 
         // then
         verify(contentRepository, times(1)).save(any(Book.class));
+        verify(s3Service, times(2)).upload(any(MultipartFile.class), anyString());
     }
 
     @Test
@@ -96,13 +101,17 @@ class ContentServiceTest {
                 .tags(null)
                 .build();
 
-        MultipartFile file = new MockMultipartFile("image.jpg", new byte[100]);
+        MultipartFile poster = new MockMultipartFile("poster.jpg", "poster.jpg", "image/jpg", new byte[100]);
+        List<MultipartFile> gallery = Collections.singletonList(
+                new MockMultipartFile("gallery.jpg", "gallery.jpg", "image/jpg", new byte[100])
+        );
 
         // when
-        contentService.saveBookWithImage(request, file);
+        contentService.saveBookWithImage(request, poster, gallery);
 
         // then
         verify(contentRepository, times(1)).save(any(Book.class));
+        verify(s3Service, times(2)).upload(any(MultipartFile.class), anyString());
     }
 
     @Test
@@ -133,7 +142,10 @@ class ContentServiceTest {
                 .tags(Collections.singletonList(1L))
                 .build();
 
-        MultipartFile file = new MockMultipartFile("image.jpg", new byte[100]);
+        MultipartFile poster = new MockMultipartFile("poster.jpg", "poster.jpg", "image/jpg", new byte[100]);
+        List<MultipartFile> gallery = Collections.singletonList(
+                new MockMultipartFile("gallery.jpg", "gallery.jpg", "image/jpg", new byte[100])
+        );
 
         given(participantRepository.findListIn(anySet()))
                 .willReturn(Collections.singletonList(participant));
@@ -143,10 +155,11 @@ class ContentServiceTest {
         given(tag.getId()).willReturn(1L);
 
         // when
-        contentService.saveMovieWithImage(request, file);
+        contentService.saveMovieWithImage(request, poster, gallery);
 
         // then
         verify(contentRepository, times(1)).save(any(Movie.class));
+        verify(s3Service, times(2)).upload(any(MultipartFile.class), anyString());
     }
 
     @Test
@@ -168,13 +181,17 @@ class ContentServiceTest {
                 .tags(null)
                 .build();
 
-        MultipartFile file = new MockMultipartFile("image.jpg", new byte[100]);
+        MultipartFile poster = new MockMultipartFile("poster.jpg", "poster.jpg", "image/jpg", new byte[100]);
+        List<MultipartFile> gallery = Collections.singletonList(
+                new MockMultipartFile("gallery.jpg", "gallery.jpg", "image/jpg", new byte[100])
+        );
 
         // when
-        contentService.saveMovieWithImage(request, file);
+        contentService.saveMovieWithImage(request, poster, gallery);
 
         // then
         verify(contentRepository, times(1)).save(any(Movie.class));
+        verify(s3Service, times(2)).upload(any(MultipartFile.class), anyString());
     }
 
     @Test
@@ -202,7 +219,10 @@ class ContentServiceTest {
                 .tags(Collections.singletonList(1L))
                 .build();
 
-        MultipartFile file = new MockMultipartFile("image.jpg", new byte[100]);
+        MultipartFile poster = new MockMultipartFile("poster.jpg", "poster.jpg", "image/jpg", new byte[100]);
+        List<MultipartFile> gallery = Collections.singletonList(
+                new MockMultipartFile("gallery.jpg", "gallery.jpg", "image/jpg", new byte[100])
+        );
 
         given(participantRepository.findListIn(anySet()))
                 .willReturn(Collections.singletonList(participant));
@@ -212,10 +232,11 @@ class ContentServiceTest {
         given(tag.getId()).willReturn(1L);
 
         // when
-        contentService.saveTvShowWithImage(request, file);
+        contentService.saveTvShowWithImage(request, poster, gallery);
 
         // then
         verify(contentRepository, times(1)).save(any(TvShow.class));
+        verify(s3Service, times(2)).upload(any(MultipartFile.class), anyString());
     }
 
     @Test
@@ -234,12 +255,16 @@ class ContentServiceTest {
                 .tags(null)
                 .build();
 
-        MultipartFile file = new MockMultipartFile("image.jpg", new byte[100]);
+        MultipartFile poster = new MockMultipartFile("poster.jpg", "poster.jpg", "image/jpg", new byte[100]);
+        List<MultipartFile> gallery = Collections.singletonList(
+                new MockMultipartFile("gallery.jpg", "gallery.jpg", "image/jpg", new byte[100])
+        );
 
         // when
-        contentService.saveTvShowWithImage(request, file);
+        contentService.saveTvShowWithImage(request, poster, gallery);
 
         // then
         verify(contentRepository, times(1)).save(any(TvShow.class));
+        verify(s3Service, times(2)).upload(any(MultipartFile.class), anyString());
     }
 }

--- a/src/test/java/com/devpedia/watchapedia/service/ParticipantServiceTest.java
+++ b/src/test/java/com/devpedia/watchapedia/service/ParticipantServiceTest.java
@@ -40,6 +40,7 @@ class ParticipantServiceTest {
         // given
         ParticipantDto.ParticipantInsertRequest request = ParticipantDto.ParticipantInsertRequest.builder()
                 .name("name")
+                .job("job")
                 .description("desc")
                 .build();
         MultipartFile file = new MockMultipartFile("image.jpg", new byte[100]);
@@ -57,6 +58,7 @@ class ParticipantServiceTest {
         // given
         ParticipantDto.ParticipantInsertRequest request = ParticipantDto.ParticipantInsertRequest.builder()
                 .name("name")
+                .job("job")
                 .description("desc")
                 .build();
         MultipartFile file = null;
@@ -74,6 +76,7 @@ class ParticipantServiceTest {
         // given
         Participant participant = Participant.builder()
                 .name("name")
+                .job("job")
                 .description("desc")
                 .profileImage(null)
                 .build();
@@ -92,11 +95,13 @@ class ParticipantServiceTest {
         // given
         ParticipantDto.ParticipantUpdateRequest request = ParticipantDto.ParticipantUpdateRequest.builder()
                 .name("modName")
+                .job("modJob")
                 .description("modDesc")
                 .build();
 
         Participant participant = Participant.builder()
                 .name("name")
+                .job("job")
                 .description("desc")
                 .profileImage(null)
                 .build();
@@ -117,6 +122,7 @@ class ParticipantServiceTest {
         // given
         ParticipantDto.ParticipantUpdateRequest request = ParticipantDto.ParticipantUpdateRequest.builder()
                 .name("modName")
+                .job("modJob")
                 .description("modDesc")
                 .build();
 
@@ -135,6 +141,7 @@ class ParticipantServiceTest {
         // given
         Participant participant = Participant.builder()
                 .name("name")
+                .job("job")
                 .description("desc")
                 .profileImage(null)
                 .build();

--- a/src/test/java/com/devpedia/watchapedia/service/ParticipantServiceTest.java
+++ b/src/test/java/com/devpedia/watchapedia/service/ParticipantServiceTest.java
@@ -49,7 +49,7 @@ class ParticipantServiceTest {
         participantService.addWithImage(request, file);
 
         // then
-        verify(s3Service, times(1)).upload(any(), anyString());
+        verify(s3Service, times(1)).upload(any(MultipartFile.class), anyString());
         verify(participantRepository, times(1)).save(any(Participant.class));
     }
 
@@ -67,7 +67,7 @@ class ParticipantServiceTest {
         participantService.addWithImage(request, file);
 
         // then
-        verify(s3Service, times(0)).upload(any(), anyString());
+        verify(s3Service, times(0)).upload(any(MultipartFile.class), anyString());
         verify(participantRepository, times(1)).save(any(Participant.class));
     }
 


### PR DESCRIPTION
랭킹 엔티티 생성 및 p6spy JDBC SQL 로깅 라이브러리 추가, 개발상 편의를 위해 주석을 달아놓았고 모두 완료시 엔티티부분 주석은 삭제예정.
char_id로 구분하여 랭킹 리스트를 구분하여 뿌려줄 예정입니다. 왓챠피디아 API를 참고하여 변수명명을 진행하였습니다.