### PR TITLE
기능추가: 랭킹 엔티티 설계 및 비즈니스로직 추가 및 랭킹 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'org.apache.httpcomponents:httpclient:4.5.9'
-
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'
 	implementation 'org.apache.commons:commons-lang3:3.9'
 
 	implementation 'io.springfox:springfox-swagger2:2.9.2'

--- a/src/main/java/com/devpedia/watchapedia/config/WebSecurityConfig.java
+++ b/src/main/java/com/devpedia/watchapedia/config/WebSecurityConfig.java
@@ -39,6 +39,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                 .antMatchers("/auth/**")
                 .antMatchers("/public/**");
+
+
     }
 
     @Override

--- a/src/main/java/com/devpedia/watchapedia/controller/RankingController.java
+++ b/src/main/java/com/devpedia/watchapedia/controller/RankingController.java
@@ -1,0 +1,27 @@
+package com.devpedia.watchapedia.controller;
+
+import com.devpedia.watchapedia.dto.RankingDto;
+import com.devpedia.watchapedia.service.RankingService;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class RankingController {
+
+    private final RankingService rankingService;
+
+    @GetMapping("/public/{charType}/rankings")
+    public List<RankingDto.RankingContentInfo> getRankingList(@PathVariable("charType") String chartType
+            , @RequestParam("charId") String chartId){
+        List<RankingDto.RankingContentInfo> result = rankingService.searchWithRanking(chartType, chartId);
+        return result;
+    }
+
+
+}

--- a/src/main/java/com/devpedia/watchapedia/domain/Ranking.java
+++ b/src/main/java/com/devpedia/watchapedia/domain/Ranking.java
@@ -1,0 +1,53 @@
+package com.devpedia.watchapedia.domain;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(columnNames = { "chartRank", "chartType", "chartId" }))
+public class Ranking{
+    @Id @GeneratedValue
+    @Column(name = "ranking_id")
+    private Long id;
+
+    /**
+     * 차트 랭킹 (1~30)
+     */
+    @Column(nullable = false)
+    private Long chartRank;
+
+    /**
+     * 영화: movies, TV 프로그램: tvshows, 책: books
+     */
+
+    @Column(nullable = false)
+    private String chartType;
+
+    /**
+     * box_office:박스오피스, mars:왓챠, netflix: 넷플릭스, predicted_rating: 별점, person:감독, person:배우, tag_match:태그, deck:컬렉션, deck_all: 모든컬렉션
+     */
+    @Column(nullable = false)
+    private String chartId;
+
+
+    /**
+     * 콘텐츠 리스트
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "content_id")
+    private Content content;
+
+    public Ranking(Long chartRank, String chartType, String chartId, Content content){
+        this.chartRank = chartRank;
+        this.chartType = chartType;
+        this.chartId = chartId;
+        this.content = content;
+    }
+
+}

--- a/src/main/java/com/devpedia/watchapedia/dto/RankingDto.java
+++ b/src/main/java/com/devpedia/watchapedia/dto/RankingDto.java
@@ -1,0 +1,26 @@
+package com.devpedia.watchapedia.dto;
+
+import com.devpedia.watchapedia.domain.Content;
+import com.devpedia.watchapedia.domain.Ranking;
+import lombok.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RankingDto {
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RankingContentInfo{
+        private Long id;
+        private Long chartRank;
+        private String chartType;
+        private Content content;
+        public RankingContentInfo(Ranking ranking) {
+            this.id = ranking.getId();
+            this.chartRank = ranking.getChartRank();
+            this.chartType = ranking.getChartType();
+        }
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/repository/RankingRepository.java
+++ b/src/main/java/com/devpedia/watchapedia/repository/RankingRepository.java
@@ -1,0 +1,23 @@
+package com.devpedia.watchapedia.repository;
+
+import com.devpedia.watchapedia.domain.Ranking;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import javax.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RankingRepository {
+    private final EntityManager em;
+    public List<Ranking> findChartId(String chartType, String chartId){
+        List<Ranking> rankings = em.createQuery("select r from Ranking r where chartId = :chartId and chartType = :chartType", Ranking.class)
+                .setParameter("chartId",chartId)
+                .setParameter("chartType", chartType)
+                .getResultList();
+        return rankings;
+    }
+
+}

--- a/src/main/java/com/devpedia/watchapedia/service/RankingService.java
+++ b/src/main/java/com/devpedia/watchapedia/service/RankingService.java
@@ -1,0 +1,27 @@
+package com.devpedia.watchapedia.service;
+
+import com.devpedia.watchapedia.domain.Ranking;
+import com.devpedia.watchapedia.dto.RankingDto;
+import com.devpedia.watchapedia.repository.RankingRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.List;
+import java.util.stream.Collectors;
+
+
+@Service
+@Slf4j
+@Transactional
+@RequiredArgsConstructor
+public class RankingService {
+    private final RankingRepository rankingRepository;
+
+    public List<RankingDto.RankingContentInfo> searchWithRanking(String chart_type, String chart_id) {
+        List<Ranking> rankingList = rankingRepository.findChartId(chart_type, chart_id);
+        return rankingList.stream()
+                .map(RankingDto.RankingContentInfo::new)
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
기능추가1 :
[fe10ecb] 랭킹 엔티티 생성 및 p6spy JDBC SQL 로깅 라이브러리 추가 , 개발상 편의를 위해 주석을 달아놓았고 모두 완료시 엔티티부분 주석은 삭제예정입니다. char_id로 구분하여 랭킹 리스트를 구분하여 뿌려줄 예정입니다. 왓챠피디아 Network Connection API Path에 맞춰 진행하였습니다.

기능추가 2:
[80a36d9],[c13b4c6] 랭킹엔티티 연관관계 수정 및 다중 유니크제약조건을 추가하였으며 [55dfddd] 랭킹 DTO, 레파지토리, 서비스 기본 구성을 추가하였습니다.

기능추가 3 : [cd5753b] 랭킹 컨트롤러 추가 @Pathvariable chart_type(movies, tvshows, books : String) 경로 처리, chart_id에 따른 랭킹 값 조회 API 구현

기능 변경 1: [1ae88dd] 컨텐츠 엔티티 수정 및 랭킹 엔티티 수정

기능 변경 2: [cd5753b] 인증 회피 위하여 스프링 시큐리티 /api/home/** 경로 ignoring Path 추가