### PR TITLE
버그: 스프링 시큐리티 관련 수정

### DIFF
--- a/src/main/java/com/devpedia/watchapedia/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/devpedia/watchapedia/security/JwtAuthenticationFilter.java
@@ -26,10 +26,8 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         try {
             Authentication authentication = jwtTokenProvider.getAuthentication(token);
             SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        // ExpiredJwtException, SignatureException, MalformedJwtException, UnsupportedJwtException
         } catch (JwtException | IllegalArgumentException e) {
-            ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+//            ((HttpServletResponse) response).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         }
 
         chain.doFilter(request, response);

--- a/src/main/java/com/devpedia/watchapedia/security/SecurityEntryPoint.java
+++ b/src/main/java/com/devpedia/watchapedia/security/SecurityEntryPoint.java
@@ -13,13 +13,21 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Set;
 
 @ControllerAdvice
 public class SecurityEntryPoint implements AuthenticationEntryPoint {
 
+    private static final Set<Integer> bypass = Set.of(
+            HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+            HttpServletResponse.SC_NOT_FOUND,
+            HttpServletResponse.SC_METHOD_NOT_ALLOWED);
+
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
         // 401
+        if (bypass.contains(response.getStatus())) return;
         response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
     }
 


### PR DESCRIPTION
서버에서 500에러나 404 405 등의 에러를 줄때
무조건 401로 응답이 나가는 버그가 존재

이는 스프링 시큐리티 ignoring 설정이
실제로 시큐리티 필터를 bypass하는것이 아니라
그런 척만 하는거라 발생하는 문제이다.

일단 해당 에러들에 대해 401로 응답하지 않도록 수정함.