### PR TITLE
기능변경: 비지니스에러 처리 변경

### DIFF
--- a/src/main/java/com/devpedia/watchapedia/exception/handler/BusinessExceptionHandler.java
+++ b/src/main/java/com/devpedia/watchapedia/exception/handler/BusinessExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.devpedia.watchapedia.exception.handler;
 
 import com.devpedia.watchapedia.exception.*;
+import com.devpedia.watchapedia.exception.common.BusinessException;
 import com.devpedia.watchapedia.exception.common.ErrorResponse;
 import lombok.extern.log4j.Log4j2;
 import org.springframework.http.ResponseEntity;
@@ -10,34 +11,10 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 @ControllerAdvice
 @Log4j2
 public class BusinessExceptionHandler {
-    @ExceptionHandler(EntityNotExistException.class)
-    protected ResponseEntity<ErrorResponse> handleBindException(EntityNotExistException e) {
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(BusinessException e) {
         ErrorResponse response = ErrorResponse.from(e);
         return new ResponseEntity<>(response, response.getStatus());
     }
-
-    @ExceptionHandler(ValueDuplicatedException.class)
-    protected ResponseEntity<ErrorResponse> handleBindException(ValueDuplicatedException e) {
-        ErrorResponse response = ErrorResponse.from(e);
-        return new ResponseEntity<>(response, response.getStatus());
-    }
-
-    @ExceptionHandler(ValueNotMatchException.class)
-    protected ResponseEntity<ErrorResponse> handleBindException(ValueNotMatchException e) {
-        ErrorResponse response = ErrorResponse.from(e);
-        return new ResponseEntity<>(response, response.getStatus());
-    }
-
-    @ExceptionHandler(ExternalIOException.class)
-    protected ResponseEntity<ErrorResponse> handleBindException(ExternalIOException e) {
-        ErrorResponse response = ErrorResponse.from(e);
-        return new ResponseEntity<>(response, response.getStatus());
-    }
-
-    @ExceptionHandler(InvalidFileException.class)
-    protected ResponseEntity<ErrorResponse> handleBindException(InvalidFileException e) {
-        ErrorResponse response = ErrorResponse.from(e);
-        return new ResponseEntity<>(response, response.getStatus());
-    }
-
 }


### PR DESCRIPTION
기존 개별 exception에 대한 처리를 일일이 했던 것을
공통 부모 객체인 BusinessException에 대한 처리로 변경

초기 의도는 개별로 적용시켜 유연성을 확보하고자 했으나
별 의미없고 매번 추가시 마다 핸들러를 수정해야했으므로 수정함.
이제는 그냥 ErrorCode랑 BusinessException을 상속받은 클래스만 만들어서
바로 던지기만 하면 된다.