### PR TITLE
기능수정: 스프링 시큐리티 Permit 경로 추가

### DIFF
--- a/src/main/java/com/devpedia/watchapedia/config/WebSecurityConfig.java
+++ b/src/main/java/com/devpedia/watchapedia/config/WebSecurityConfig.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
@@ -24,8 +25,8 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final JwtTokenProvider jwtTokenProvider;
 
+    // -- swagger ui
     private static final String[] AUTH_WHITELIST = {
-            // -- swagger ui
             "/swagger-resources/**",
             "/swagger-ui.html",
             "/v2/api-docs",
@@ -39,8 +40,6 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                 .antMatchers("/auth/**")
                 .antMatchers("/public/**");
-
-
     }
 
     @Override
@@ -55,6 +54,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                 .authorizeRequests()
                     .antMatchers("/admin/**").hasAuthority("ADMIN")
+                    .antMatchers(HttpMethod.GET).permitAll()
                     .antMatchers(AUTH_WHITELIST).permitAll()
                     .anyRequest().authenticated()
                 .and()


### PR DESCRIPTION
API 중 User Context(토큰정보)가 필요한 경우가 있어서 설정을 변경함.
Admin이 아닌 모든 GET요청은 인증여부을 체크하지않고 필요에 따라 헤더의 토큰정보를
가져올 수 있다. 토큰 정보가 필요하다면 /public/** 형태의 Url 사용하지 말것.