### PR TITLE
기능추가: 로깅시스템 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 
+	implementation 'net.logstash.logback:logstash-logback-encoder:6.5'
 	implementation 'io.jsonwebtoken:jjwt:0.9.1'
 	implementation 'org.apache.httpcomponents:httpclient:4.5.9'
 	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.6'

--- a/src/main/java/com/devpedia/watchapedia/config/WebMvcConfig.java
+++ b/src/main/java/com/devpedia/watchapedia/config/WebMvcConfig.java
@@ -4,14 +4,21 @@ import com.devpedia.watchapedia.controller.UserController;
 import com.devpedia.watchapedia.dto.enums.ContentTypeParameterConverter;
 import com.devpedia.watchapedia.dto.enums.InterestContentOrderConverter;
 import com.devpedia.watchapedia.dto.enums.RatingContentOrderConverter;
+import com.devpedia.watchapedia.logging.LoggingInterceptor;
 import com.devpedia.watchapedia.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final LoggingInterceptor loggingInterceptor;
+
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
@@ -29,5 +36,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
         registry.addConverter(new RatingContentOrderConverter());
         registry.addConverter(new InterestContentOrderConverter());
         registry.addConverter(new ContentTypeParameterConverter());
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loggingInterceptor).excludePathPatterns(WebSecurityConfig.SWAGGER_AUTH_WHITELIST);
     }
 }

--- a/src/main/java/com/devpedia/watchapedia/config/WebSecurityConfig.java
+++ b/src/main/java/com/devpedia/watchapedia/config/WebSecurityConfig.java
@@ -26,7 +26,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
     private final JwtTokenProvider jwtTokenProvider;
 
     // -- swagger ui
-    private static final String[] AUTH_WHITELIST = {
+    public static final String[] SWAGGER_AUTH_WHITELIST = {
             "/swagger-resources/**",
             "/swagger-ui.html",
             "/v2/api-docs",
@@ -55,7 +55,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
                 .authorizeRequests()
                     .antMatchers("/admin/**").hasAuthority("ADMIN")
                     .antMatchers(HttpMethod.GET).permitAll()
-                    .antMatchers(AUTH_WHITELIST).permitAll()
+                    .antMatchers(SWAGGER_AUTH_WHITELIST).permitAll()
                     .anyRequest().authenticated()
                 .and()
                 .exceptionHandling()

--- a/src/main/java/com/devpedia/watchapedia/exception/common/ErrorCode.java
+++ b/src/main/java/com/devpedia/watchapedia/exception/common/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
     // A: Etc
     ACCESS_NOT_AVAILABLE(BAD_REQUEST, "A001", "조회할 권한이 없습니다."),
     CONTENT_TYPE_NOT_VALID(INTERNAL_SERVER_ERROR, "A002", "Class 타입 변환 실패"),
+    INTERNAL_ERROR(INTERNAL_SERVER_ERROR, "A999", "Unknown Internal Error"),
 
     // B: IO Fail
     OAUTH_PROVIDER_FAIL(BAD_REQUEST, "B001", "OAuth인증에 실패했습니다"),

--- a/src/main/java/com/devpedia/watchapedia/exception/handler/CommonExceptionHandler.java
+++ b/src/main/java/com/devpedia/watchapedia/exception/handler/CommonExceptionHandler.java
@@ -16,11 +16,26 @@ import org.springframework.web.method.annotation.MethodArgumentTypeMismatchExcep
 import org.springframework.web.multipart.support.MissingServletRequestPartException;
 
 import javax.validation.ConstraintViolationException;
+import java.util.Arrays;
 import java.util.Objects;
+import java.util.stream.Collectors;
+
+import static net.logstash.logback.argument.StructuredArguments.*;
 
 @ControllerAdvice
 @Log4j2
 public class CommonExceptionHandler {
+    @ExceptionHandler(RuntimeException.class)
+    protected ResponseEntity<ErrorResponse> handleBindException(RuntimeException e) {
+        String stackTrace = Arrays.stream(e.getStackTrace()).map(StackTraceElement::toString).collect(Collectors.joining(" "));
+        log.error("{} {} {}",
+                keyValue("exception_stack_trace", stackTrace),
+                keyValue("exception_class", e.getClass().getSimpleName()),
+                keyValue("exception_message", e.getMessage()));
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_ERROR);
+        return new ResponseEntity<>(response, response.getStatus());
+    }
+
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ErrorResponse> handleBindException(MethodArgumentNotValidException e) {
         ErrorResponse response = ErrorResponse.of(ErrorCode.INPUT_VALUE_INVALID, e.getBindingResult());

--- a/src/main/java/com/devpedia/watchapedia/logging/CustomServletWrappingFilter.java
+++ b/src/main/java/com/devpedia/watchapedia/logging/CustomServletWrappingFilter.java
@@ -1,0 +1,23 @@
+package com.devpedia.watchapedia.logging;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class CustomServletWrappingFilter extends OncePerRequestFilter {
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        ContentCachingRequestWrapper wrappingRequest = new ContentCachingRequestWrapper(request);
+        ContentCachingResponseWrapper wrappingResponse = new ContentCachingResponseWrapper(response);
+        filterChain.doFilter(wrappingRequest, wrappingResponse);
+        wrappingResponse.copyBodyToResponse();
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/logging/LogUtil.java
+++ b/src/main/java/com/devpedia/watchapedia/logging/LogUtil.java
@@ -1,0 +1,79 @@
+package com.devpedia.watchapedia.logging;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import static net.logstash.logback.argument.StructuredArguments.entries;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class LogUtil {
+
+    private final ObjectMapper mapper;
+
+    public void logApi(HttpServletRequest request, HttpServletResponse response, JsonNode requestBody , JsonNode responseBody) throws Exception{
+        Map<String, Object> logs = new HashMap<>();
+
+        logs.put("request_method", request.getMethod());
+        logs.put("request_url", request.getRequestURI());
+        logs.put("request_headers", buildHeadersMap(request));
+        logs.put("request_parameters", buildParametersMap(request));
+        logs.put("request_body", mapper.writeValueAsString(requestBody));
+        logs.put("response_status", response.getStatus());
+        logs.put("response_headers", buildHeadersMap(response));
+        logs.put("response_body", mapper.writeValueAsString(responseBody));
+
+        if (responseBody.has("status") && responseBody.has("code"))
+            logs.put("response_error_code", responseBody.get("code").textValue());
+
+        log.info("api log {}", entries(logs));
+    }
+
+    private Map<String, String> buildParametersMap(HttpServletRequest httpServletRequest) {
+        Map<String, String> resultMap = new HashMap<>();
+        Enumeration<String> parameterNames = httpServletRequest.getParameterNames();
+
+        while (parameterNames.hasMoreElements()) {
+            String key = parameterNames.nextElement();
+            String value = httpServletRequest.getParameter(key);
+            resultMap.put(key, value);
+        }
+
+        return resultMap;
+    }
+
+    private Map<String, String> buildHeadersMap(HttpServletRequest request) {
+        Map<String, String> map = new HashMap<>();
+
+        Enumeration<String> headerNames = request.getHeaderNames();
+        while (headerNames.hasMoreElements()) {
+            String key = headerNames.nextElement();
+            String value = request.getHeader(key);
+            map.put(key, value);
+        }
+
+        return map;
+    }
+
+    private Map<String, String> buildHeadersMap(HttpServletResponse response) {
+        Map<String, String> map = new HashMap<>();
+
+        Collection<String> headerNames = response.getHeaderNames();
+        for (String header : headerNames) {
+            map.put(header, response.getHeader(header));
+        }
+
+        return map;
+    }
+}

--- a/src/main/java/com/devpedia/watchapedia/logging/LoggingInterceptor.java
+++ b/src/main/java/com/devpedia/watchapedia/logging/LoggingInterceptor.java
@@ -1,0 +1,35 @@
+package com.devpedia.watchapedia.logging;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class LoggingInterceptor extends HandlerInterceptorAdapter {
+
+    private final ObjectMapper mapper;
+    private final LogUtil logUtil;
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
+        if (request instanceof ContentCachingRequestWrapper && response instanceof ContentCachingResponseWrapper) {
+            final ContentCachingRequestWrapper cachingRequest = (ContentCachingRequestWrapper) request;
+            final ContentCachingResponseWrapper cachingResponse = (ContentCachingResponseWrapper) response;
+
+            JsonNode requestBody = mapper.readTree(cachingRequest.getContentAsByteArray());
+            JsonNode responseBody = mapper.readTree(cachingResponse.getContentAsByteArray());
+
+            logUtil.logApi(request, response, requestBody, responseBody);
+        }
+    }
+}

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/base.xml" />
+
+    <property name="LOGSTASH_URL" value="222.111.195.42:5000" />
+
+    <appender name="LOGSTASH_API" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>${LOGSTASH_URL}</destination>
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <mdc />
+                <pattern>
+                    <pattern>
+                        { "serviceID": "watchapedia" }
+                    </pattern>
+                </pattern>
+                <arguments fieldName="logs" />
+                <timestamp />
+                <context />
+                <threadName />
+                <logLevel />
+                <loggerName />
+                <logstashMarkers />
+                <stackTrace />
+                <callerData />
+            </providers>
+        </encoder>
+    </appender>
+
+    <appender name="LOGSTASH_ERROR" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+            <level>error</level>
+            <onMatch>ACCEPT</onMatch>
+            <onMismatch>DENY</onMismatch>
+        </filter>
+        <destination>${LOGSTASH_URL}</destination>
+        <encoder class="net.logstash.logback.encoder.LoggingEventCompositeJsonEncoder">
+            <providers>
+                <mdc />
+                <pattern>
+                    <pattern>
+                        { "serviceID": "watchapedia" }
+                    </pattern>
+                </pattern>
+                <arguments fieldName="stackTrace" />
+                <arguments fieldName="exception" />
+                <timestamp />
+                <context />
+                <threadName />
+                <logLevel />
+                <loggerName />
+                <logstashMarkers />
+                <callerData />
+            </providers>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="CONSOLE" />
+        <appender-ref ref="LOGSTASH_ERROR" />
+    </root>
+
+    <logger name="com.devpedia.watchapedia.logging.LogUtil" level="INFO" additivity="false">
+        <appender-ref ref="LOGSTASH_API" />
+    </logger>
+</configuration>


### PR DESCRIPTION
ELK 스택 로깅시스템 구축
서버에서 발생하는 모든 Request & Response 의
Header, Body, Parameter 등이 로그서버에 저장된다.
트래픽 규모가 크지않기 때문에 별도의 메세지큐나 파일적재를 이용하지 않고
로그가 찍히는 즉시 서버로 tcp 전송을 한다.

- 에러 발생 시
Exception Handler에 정의된 에러 = 일반 요청 응답과 동일하게 처리
예상치 못한 Exception 발생 시 = 일단 A999 코드로 받아서 핸들링 후
StackTrace와 예외클래스 이름을 로그로 남긴다.