### PR TITLE
버그: ddl-auto 설정 롤백

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     driver-class-name: org.mariadb.jdbc.Driver
   jpa:
     hibernate:
-      ddl-auto: none
+      ddl-auto: update
     properties:
       hibernate:
         jdbc:


### PR DESCRIPTION
hibernate.ddl-auto 를 update -> none 으로 수정했더니
테스트코드에서 시퀀스 테이블을 인식못하는 오류가 생겨서 일단 롤백함